### PR TITLE
Show permissions required dialog

### DIFF
--- a/app/src/main/java/com/kinandcarta/create/proxytoggle/view/MainActivity.kt
+++ b/app/src/main/java/com/kinandcarta/create/proxytoggle/view/MainActivity.kt
@@ -1,9 +1,13 @@
 package com.kinandcarta.create.proxytoggle.view
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import com.kinandcarta.create.proxytoggle.R
 import com.kinandcarta.create.proxytoggle.feature.manager.view.ProxyManagerFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -17,6 +21,23 @@ class MainActivity : AppCompatActivity(R.layout.main_activity) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        when (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_SECURE_SETTINGS)) {
+            PackageManager.PERMISSION_DENIED -> showPermissionRequiredDialog()
+            PackageManager.PERMISSION_GRANTED -> showApplicationContent(savedInstanceState)
+        }
+    }
+
+    private fun showPermissionRequiredDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.dialog_title_special_permissions))
+            .setMessage(getString(R.string.dialog_message_special_permissions))
+            .setCancelable(false)
+            .create()
+            .show()
+    }
+
+    private fun showApplicationContent(savedInstanceState: Bundle?) {
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.container, ProxyManagerFragment.newInstance())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Proxy Toggle</string>
+    <string name="dialog_title_special_permissions">Special permissions required</string>
+    <string name="dialog_message_special_permissions">This app needs special permissions that can only be granted by connecting this device to your computer and running a command from Terminal. You can find out how in the README.</string>
 </resources>


### PR DESCRIPTION
### Why?

We can't request the special permissions on runtime. The only thing we can do is make sure they've been granted via adb shell.

### What?

Show a dialog whenever the app doesn't have the required permissions, pointing out where to find the instructions to do so.