### PR TITLE
Implement a ThemeSwitcher to alternate between dark and light mode

### DIFF
--- a/app/src/main/java/com/kinandcarta/create/proxytoggle/android/SharedPrefsAppSettings.kt
+++ b/app/src/main/java/com/kinandcarta/create/proxytoggle/android/SharedPrefsAppSettings.kt
@@ -1,6 +1,7 @@
 package com.kinandcarta.create.proxytoggle.android
 
 import android.content.Context
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
 import com.kinandcarta.create.proxytoggle.model.Proxy
 import com.kinandcarta.create.proxytoggle.model.ProxyMapper
@@ -16,6 +17,7 @@ class SharedPrefsAppSettings @Inject constructor(
     companion object {
         private const val SHARED_PREF_NAME = "AppSettings"
         private const val PREF_PROXY = "proxy"
+        private const val PREF_THEME = "theme"
     }
 
     private val prefs by lazy {
@@ -25,4 +27,8 @@ class SharedPrefsAppSettings @Inject constructor(
     override var lastUsedProxy: Proxy
         get() = proxyMapper.from(prefs.getString(PREF_PROXY, null))
         set(value) = prefs.edit { putString(PREF_PROXY, value.toString()) }
+
+    override var themeMode: Int
+        get() = prefs.getInt(PREF_THEME, AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+        set(value) = prefs.edit { putInt(PREF_THEME, value) }
 }

--- a/app/src/main/java/com/kinandcarta/create/proxytoggle/android/ThemeSwitcher.kt
+++ b/app/src/main/java/com/kinandcarta/create/proxytoggle/android/ThemeSwitcher.kt
@@ -1,0 +1,51 @@
+package com.kinandcarta.create.proxytoggle.android
+
+import android.content.Context
+import android.content.res.Configuration.UI_MODE_NIGHT_MASK
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.appcompat.app.AppCompatDelegate
+import com.kinandcarta.create.proxytoggle.settings.AppSettings
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ActivityScoped
+import javax.inject.Inject
+
+@ActivityScoped
+class ThemeSwitcher @Inject constructor(
+    @ApplicationContext context: Context,
+    private val appSettings: AppSettings
+) {
+
+    init {
+        val mode =
+            when {
+                appSettings.themeMode.isNightMode() || appSettings.themeMode.isLightMode() -> {
+                    appSettings.themeMode
+                }
+                context.isSetToDarkMode() -> {
+                    AppCompatDelegate.MODE_NIGHT_YES
+                }
+                else -> {
+                    AppCompatDelegate.MODE_NIGHT_NO
+                }
+            }
+        setTheme(mode)
+    }
+
+    fun toggleTheme() {
+        if (appSettings.themeMode.isNightMode()) {
+            setTheme(AppCompatDelegate.MODE_NIGHT_NO)
+        } else {
+            setTheme(AppCompatDelegate.MODE_NIGHT_YES)
+        }
+    }
+
+    private fun setTheme(mode: Int) {
+        appSettings.themeMode = mode
+        AppCompatDelegate.setDefaultNightMode(mode)
+    }
+
+    private fun Int.isNightMode() = this == AppCompatDelegate.MODE_NIGHT_YES
+    private fun Int.isLightMode() = this == AppCompatDelegate.MODE_NIGHT_NO
+    private fun Context.isSetToDarkMode() =
+        this.resources.configuration.uiMode and UI_MODE_NIGHT_MASK == UI_MODE_NIGHT_YES
+}

--- a/app/src/main/java/com/kinandcarta/create/proxytoggle/android/ThemeSwitcher.kt
+++ b/app/src/main/java/com/kinandcarta/create/proxytoggle/android/ThemeSwitcher.kt
@@ -5,13 +5,13 @@ import android.content.res.Configuration.UI_MODE_NIGHT_MASK
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.appcompat.app.AppCompatDelegate
 import com.kinandcarta.create.proxytoggle.settings.AppSettings
-import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
 import javax.inject.Inject
 
 @ActivityScoped
 class ThemeSwitcher @Inject constructor(
-    @ApplicationContext context: Context,
+    @ActivityContext context: Context,
     private val appSettings: AppSettings
 ) {
 

--- a/app/src/main/java/com/kinandcarta/create/proxytoggle/feature/manager/view/ProxyManagerFragment.kt
+++ b/app/src/main/java/com/kinandcarta/create/proxytoggle/feature/manager/view/ProxyManagerFragment.kt
@@ -59,7 +59,6 @@ class ProxyManagerFragment : Fragment() {
         })
     }
 
-    @SuppressWarnings("MagicNumber")
     private fun setupIcons() {
         // Info icon
         binding.info.setOnClickListener {
@@ -71,7 +70,6 @@ class ProxyManagerFragment : Fragment() {
         }
 
         // Theme mode icon
-//        binding.themeMode.extendTouchArea(20.px)
         binding.themeMode.setOnClickListener { viewModel.toggleTheme() }
     }
 

--- a/app/src/main/java/com/kinandcarta/create/proxytoggle/feature/manager/view/ProxyManagerFragment.kt
+++ b/app/src/main/java/com/kinandcarta/create/proxytoggle/feature/manager/view/ProxyManagerFragment.kt
@@ -33,14 +33,14 @@ class ProxyManagerFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.info.requestFocusFromTouch()
-        binding.info.setOnClickListener { showInfoDialog() }
-        viewModel.proxyState.observe(viewLifecycleOwner, Observer { proxyState ->
-            when (proxyState) {
-                is ProxyState.Enabled -> showProxyEnabled(proxyState.address, proxyState.port)
-                is ProxyState.Disabled -> showProxyDisabled()
-            }
-        })
+
+        setupIcons()
+
+        observeProxyState()
+        observeProxyEvent()
+    }
+
+    private fun observeProxyEvent() {
         viewModel.proxyEvent.observe(viewLifecycleOwner, Observer { proxyEvent ->
             hideErrors()
             when (proxyEvent) {
@@ -48,6 +48,31 @@ class ProxyManagerFragment : Fragment() {
                 is ProxyManagerEvent.InvalidPort -> showInvalidPortError()
             }
         })
+    }
+
+    private fun observeProxyState() {
+        viewModel.proxyState.observe(viewLifecycleOwner, Observer { proxyState ->
+            when (proxyState) {
+                is ProxyState.Enabled -> showProxyEnabled(proxyState.address, proxyState.port)
+                is ProxyState.Disabled -> showProxyDisabled()
+            }
+        })
+    }
+
+    @SuppressWarnings("MagicNumber")
+    private fun setupIcons() {
+        // Info icon
+        binding.info.setOnClickListener {
+            dialog?.dismiss()
+            dialog = AlertDialog.Builder(requireContext())
+                .setMessage(R.string.dialog_message_information)
+                .setPositiveButton(getString(R.string.dialog_action_close)) { _, _ -> }
+                .show()
+        }
+
+        // Theme mode icon
+//        binding.themeMode.extendTouchArea(20.px)
+        binding.themeMode.setOnClickListener { viewModel.toggleTheme() }
     }
 
     private fun showProxyEnabled(proxyAddress: String, proxyPort: String) {
@@ -106,13 +131,5 @@ class ProxyManagerFragment : Fragment() {
             inputLayoutAddress.error = null
             inputLayoutPort.error = null
         }
-    }
-
-    private fun showInfoDialog() {
-        dialog?.dismiss()
-        dialog = AlertDialog.Builder(requireContext())
-            .setMessage(R.string.dialog_message_information)
-            .setPositiveButton(getString(R.string.dialog_action_close)) { _, _ -> }
-            .show()
     }
 }

--- a/app/src/main/java/com/kinandcarta/create/proxytoggle/feature/manager/viewmodel/ProxyManagerViewModel.kt
+++ b/app/src/main/java/com/kinandcarta/create/proxytoggle/feature/manager/viewmodel/ProxyManagerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import com.kinandcarta.create.proxytoggle.android.DeviceSettingsManager
 import com.kinandcarta.create.proxytoggle.android.ProxyValidator
+import com.kinandcarta.create.proxytoggle.android.ThemeSwitcher
 import com.kinandcarta.create.proxytoggle.extensions.SingleLiveEvent
 import com.kinandcarta.create.proxytoggle.feature.manager.view.ProxyManagerEvent
 import com.kinandcarta.create.proxytoggle.feature.manager.view.ProxyState
@@ -14,7 +15,8 @@ import com.kinandcarta.create.proxytoggle.settings.AppSettings
 class ProxyManagerViewModel @ViewModelInject constructor(
     private val deviceSettingsManager: DeviceSettingsManager,
     private val proxyValidator: ProxyValidator,
-    private val appSettings: AppSettings
+    private val appSettings: AppSettings,
+    private val themeSwitcher: ThemeSwitcher
 ) : ViewModel() {
 
     val proxyEvent = SingleLiveEvent<ProxyManagerEvent>()
@@ -45,4 +47,6 @@ class ProxyManagerViewModel @ViewModelInject constructor(
     fun disableProxy() {
         deviceSettingsManager.disableProxy()
     }
+
+    fun toggleTheme() = themeSwitcher.toggleTheme()
 }

--- a/app/src/main/java/com/kinandcarta/create/proxytoggle/settings/AppSettings.kt
+++ b/app/src/main/java/com/kinandcarta/create/proxytoggle/settings/AppSettings.kt
@@ -5,4 +5,6 @@ import com.kinandcarta.create.proxytoggle.model.Proxy
 interface AppSettings {
 
     var lastUsedProxy: Proxy
+
+    var themeMode: Int
 }

--- a/app/src/main/res/drawable/ic_switch_theme.xml
+++ b/app/src/main/res/drawable/ic_switch_theme.xml
@@ -1,0 +1,4 @@
+<vector android:height="24dp" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M20,8.69V4h-4.69L12,0.69 8.69,4H4v4.69L0.69,12 4,15.31V20h4.69L12,23.31 15.31,20H20v-4.69L23.31,12 20,8.69zM12,18c-0.89,0 -1.74,-0.2 -2.5,-0.55C11.56,16.5 13,14.42 13,12s-1.44,-4.5 -3.5,-5.45C10.26,6.2 11.11,6 12,6c3.31,0 6,2.69 6,6s-2.69,6 -6,6z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_proxy_manager.xml
+++ b/app/src/main/res/layout/fragment_proxy_manager.xml
@@ -6,6 +6,16 @@
     android:orientation="vertical">
 
     <ImageView
+        android:id="@+id/theme_mode"
+        style="@style/Icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/a11y_switch_theme"
+        android:src="@drawable/ic_switch_theme"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
         android:id="@+id/info"
         style="@style/Icon"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/accessibility.xml
+++ b/app/src/main/res/values/accessibility.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="a11y_information">Information</string>
+    <string name="a11y_switch_theme">Switch theme</string>
     <string name="a11y_enable_proxy">Enable proxy</string>
     <string name="a11y_disable_proxy">Disable proxy</string>
 </resources>

--- a/app/src/test/java/com/kinandcarta/create/proxytoggle/android/SharedPrefsAppSettingsTest.kt
+++ b/app/src/test/java/com/kinandcarta/create/proxytoggle/android/SharedPrefsAppSettingsTest.kt
@@ -40,7 +40,7 @@ class SharedPrefsAppSettingsTest {
     }
 
     @Test
-    fun `getProxy() - fetches from sharedPrefs and maps the value`() {
+    fun `getLastUsedProxy() - fetches from sharedPrefs and maps the value`() {
         every { mockSharedPreferences.getString("proxy", any()) } returns VALID_PROXY
 
         val result = subject.lastUsedProxy
@@ -54,7 +54,7 @@ class SharedPrefsAppSettingsTest {
     }
 
     @Test
-    fun `setProxy() - stores in sharedPrefs the string version of the proxy`() {
+    fun `setLastUsedProxy() - stores in sharedPrefs the string version of the proxy`() {
         val string = slot<String>()
         every { mockSharedPreferences.edit { putString("proxy", capture(string)) } } returns Unit
 
@@ -65,5 +65,30 @@ class SharedPrefsAppSettingsTest {
             assertThat(string.captured).isEqualTo(VALID_PROXY)
         }
         confirmVerified(mockProxyMapper, mockSharedPreferences)
+    }
+
+    @Test
+    fun `getThemeMode() - fetches value from sharedPrefs`() {
+        every { mockSharedPreferences.getInt("theme", any()) } returns 515
+
+        val result = subject.themeMode
+
+        verify {
+            mockSharedPreferences.getInt("theme", any())
+            assertThat(result).isEqualTo(515)
+        }
+    }
+
+    @Test
+    fun `setThemeMode() - stores value in sharedPrefs`() {
+        val mode = slot<Int>()
+        every { mockSharedPreferences.edit { putInt("theme", capture(mode)) } } returns Unit
+
+        subject.themeMode = 515
+
+        verify {
+            mockSharedPreferences.edit { putInt("theme", any()) }
+            assertThat(mode.captured).isEqualTo(515)
+        }
     }
 }

--- a/app/src/test/java/com/kinandcarta/create/proxytoggle/android/ThemeSwitcherTest.kt
+++ b/app/src/test/java/com/kinandcarta/create/proxytoggle/android/ThemeSwitcherTest.kt
@@ -1,0 +1,139 @@
+package com.kinandcarta.create.proxytoggle.android
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.appcompat.app.AppCompatDelegate
+import com.kinandcarta.create.proxytoggle.settings.AppSettings
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class ThemeSwitcherTest {
+
+    companion object {
+        private const val DARK_MODE = AppCompatDelegate.MODE_NIGHT_YES
+        private const val LIGHT_MODE = AppCompatDelegate.MODE_NIGHT_NO
+        private const val NO_MODE_SELECTED = AppCompatDelegate.MODE_NIGHT_UNSPECIFIED
+    }
+
+    @RelaxedMockK
+    private lateinit var mockContext: Context
+
+    @MockK
+    private lateinit var mockAppSettings: AppSettings
+
+    private lateinit var subject: ThemeSwitcher
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+        mockkStatic(AppCompatDelegate::class)
+
+        subject = ThemeSwitcher(mockContext, mockAppSettings)
+    }
+
+    @Test
+    fun `init - GIVEN I have dark mode selected THEN dark mode is set`() {
+        every { mockAppSettings.themeMode } returns DARK_MODE
+
+        subject = ThemeSwitcher(mockContext, mockAppSettings)
+
+        verify {
+            mockAppSettings.themeMode = DARK_MODE
+            AppCompatDelegate.setDefaultNightMode(DARK_MODE)
+        }
+    }
+
+    @Test
+    fun `init - GIVEN I have light mode selected THEN light mode is set`() {
+        every { mockAppSettings.themeMode } returns LIGHT_MODE
+
+        subject = ThemeSwitcher(mockContext, mockAppSettings)
+
+        verify {
+            mockAppSettings.themeMode = LIGHT_MODE
+            AppCompatDelegate.setDefaultNightMode(LIGHT_MODE)
+        }
+    }
+
+    @Test
+    fun `init - GIVEN I have no mode selected AND dark configuration THEN dark mode is set`() {
+        every { mockAppSettings.themeMode } returns NO_MODE_SELECTED
+        every { mockContext.resources } returns mockk {
+            every { configuration } returns mockk {
+                uiMode = Configuration.UI_MODE_NIGHT_YES
+            }
+        }
+
+        subject = ThemeSwitcher(mockContext, mockAppSettings)
+
+        verify {
+            mockAppSettings.themeMode = DARK_MODE
+            AppCompatDelegate.setDefaultNightMode(DARK_MODE)
+        }
+    }
+
+    @Test
+    fun `init - GIVEN I have no mode selected AND light configuration THEN light mode is set`() {
+        every { mockAppSettings.themeMode } returns NO_MODE_SELECTED
+        every { mockContext.resources } returns mockk {
+            every { configuration } returns mockk {
+                uiMode = Configuration.UI_MODE_NIGHT_NO
+            }
+        }
+
+        subject = ThemeSwitcher(mockContext, mockAppSettings)
+
+        verify {
+            mockAppSettings.themeMode = LIGHT_MODE
+            AppCompatDelegate.setDefaultNightMode(LIGHT_MODE)
+        }
+    }
+
+    @Test
+    fun `init - GIVEN I have no mode selected AND no configuration THEN light mode is set`() {
+        every { mockAppSettings.themeMode } returns NO_MODE_SELECTED
+        every { mockContext.resources } returns mockk {
+            every { configuration } returns mockk {
+                uiMode = Configuration.UI_MODE_NIGHT_UNDEFINED
+            }
+        }
+
+        subject = ThemeSwitcher(mockContext, mockAppSettings)
+
+        verify {
+            mockAppSettings.themeMode = LIGHT_MODE
+            AppCompatDelegate.setDefaultNightMode(LIGHT_MODE)
+        }
+    }
+
+    @Test
+    fun `toggleTheme() - GIVEN I have dark mode THEN light mode is enabled AND stored in settings`() {
+        every { mockAppSettings.themeMode } returns DARK_MODE
+
+        subject.toggleTheme()
+
+        verify {
+            mockAppSettings.themeMode = LIGHT_MODE
+            AppCompatDelegate.setDefaultNightMode(LIGHT_MODE)
+        }
+    }
+
+    @Test
+    fun `toggleTheme() - GIVEN I have light mode THEN dark mode is enabled AND stored in settings`() {
+        every { mockAppSettings.themeMode } returns LIGHT_MODE
+
+        subject.toggleTheme()
+
+        verify {
+            mockAppSettings.themeMode = DARK_MODE
+            AppCompatDelegate.setDefaultNightMode(DARK_MODE)
+        }
+    }
+}

--- a/app/src/test/java/com/kinandcarta/create/proxytoggle/feature/manager/viewmodel/ProxyManagerViewModelTest.kt
+++ b/app/src/test/java/com/kinandcarta/create/proxytoggle/feature/manager/viewmodel/ProxyManagerViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import com.google.common.truth.Truth.assertThat
 import com.kinandcarta.create.proxytoggle.android.DeviceSettingsManager
 import com.kinandcarta.create.proxytoggle.android.ProxyValidator
+import com.kinandcarta.create.proxytoggle.android.ThemeSwitcher
 import com.kinandcarta.create.proxytoggle.awaitValue
 import com.kinandcarta.create.proxytoggle.feature.manager.view.ProxyManagerEvent
 import com.kinandcarta.create.proxytoggle.feature.manager.view.ProxyState
@@ -41,6 +42,9 @@ class ProxyManagerViewModelTest {
     @MockK
     private lateinit var mockAppSettings: AppSettings
 
+    @RelaxedMockK
+    private lateinit var mockThemeSwitcher: ThemeSwitcher
+
     private val fakeLiveData = MutableLiveData(Proxy.Disabled)
 
     private lateinit var subject: ProxyManagerViewModel
@@ -65,12 +69,22 @@ class ProxyManagerViewModelTest {
         every { mockProxyValidator.isValidPort(any()) } returns true
 
         subject =
-            ProxyManagerViewModel(mockDeviceSettingsManager, mockProxyValidator, mockAppSettings)
+            ProxyManagerViewModel(
+                mockDeviceSettingsManager,
+                mockProxyValidator,
+                mockAppSettings,
+                mockThemeSwitcher
+            )
     }
 
     @After
     fun tearDown() {
-        confirmVerified(mockDeviceSettingsManager, mockProxyValidator, mockAppSettings)
+        confirmVerified(
+            mockDeviceSettingsManager,
+            mockProxyValidator,
+            mockAppSettings,
+            mockThemeSwitcher
+        )
     }
 
     @Test
@@ -135,5 +149,12 @@ class ProxyManagerViewModelTest {
 
         verify { mockAppSettings.lastUsedProxy }
         assertThat(result).isEqualTo(Proxy.Disabled)
+    }
+
+    @Test
+    fun `toggleTheme() - delegates to themeSwitcher`() {
+        subject.toggleTheme()
+
+        verify { mockThemeSwitcher.toggleTheme() }
     }
 }


### PR DESCRIPTION
### Why?

We want to give the users the option to switch between dark and light theme

### What?

Added a ThemeSwitcher that will toggle between dark and light theme, storing the preference for future uses.
Whenever the app is launched, it will first check if there's a stored setting and will apply automatically.
If there's no stored setting, it will check the device configuration. If the configuration is set to dark, it will apply the dark mode automatically.

### Bonus

Here some screenshots (dark theme is not yet implemented!)
![image](https://user-images.githubusercontent.com/1481183/86802768-3e745100-c06d-11ea-96d3-cdcbcb154082.png)
![image](https://user-images.githubusercontent.com/1481183/86802779-40d6ab00-c06d-11ea-92b9-f25cb9c44fd7.png)

