### PR TITLE
accept proxy address from intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
         <activity
             android:name=".main.MainActivity"
             android:exported="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/kinandcarta/create/proxytoggle/main/MainActivity.kt
+++ b/app/src/main/java/com/kinandcarta/create/proxytoggle/main/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.kinandcarta.create.proxytoggle.main
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -17,12 +19,14 @@ import androidx.core.content.ContextCompat
 import com.kinandcarta.create.proxytoggle.core.ui.theme.ProxyToggleTheme
 import com.kinandcarta.create.proxytoggle.manager.view.screen.BlockAppScreen
 import com.kinandcarta.create.proxytoggle.manager.view.screen.ProxyManagerScreen
+import com.kinandcarta.create.proxytoggle.manager.viewmodel.ProxyManagerViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
     private val viewModel: MainViewModel by viewModels()
+    private val proxyViewModel: ProxyManagerViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,6 +38,14 @@ class MainActivity : AppCompatActivity() {
             val useVerticalLayout = heightSizeClass != WindowHeightSizeClass.Compact
 
             MainScreen(useDarkTheme = useDarkTheme, useVerticalLayout = useVerticalLayout)
+        }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        intent?.getStringExtra(ProxyManagerViewModel.PROXY_KEY)?.takeIf { it.isNotBlank() }?.let {
+            Log.i("Intent", "On new intent $it")
+            proxyViewModel.onSetProxy(it)
         }
     }
 }


### PR DESCRIPTION
Accept proxy setting from intent's extra data

* Add `SavedStateHandle` in `ProxyManagerViewModel` to accept initial input param
* Mark MainActivity as `singleInstance` to receive any coming intent after it is started
* 2 unit test case for this new function